### PR TITLE
change hidden color biter item icon to be one of size 32x32

### DIFF
--- a/prototypes/colorkeys.lua
+++ b/prototypes/colorkeys.lua
@@ -24,7 +24,7 @@ local function createItem(data)
 	{
 		type = "item",
 		name = getRefname(data.name),
-		icon = "__core__/graphics/empty.png",
+		icon = "__core__/graphics/slot-icon-fuel.png",
 		icon_size = 1,
 		stack_size = 1,
 		order = parseColor(data),


### PR DESCRIPTION
This fixes the crash bug #2. The issue is that for some reason the hidden color biter items end up expecting the icon to be 32x32, and empty.png is 1x1.

Changing it seems to make everything work fine.